### PR TITLE
chore: improve ESLint rule; rename TS config file

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@eruptionjs/config",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "Opinionated configuration for EruptionJS projects",
   "publishConfig": {
     "access": "public"
@@ -10,7 +10,7 @@
   "exports": {
     ".": "./src/index.js",
     "./prettier": "./src/prettier.js",
-    "./typescript": "./src/tsconfig.json",
+    "./typescript": "./src/typescript.json",
     "./reset.d.ts": "./src/reset.d.ts",
     "./eslint": "./src/eslint.js",
     "./biome": "./src/biome.json"

--- a/src/eslint.js
+++ b/src/eslint.js
@@ -55,6 +55,7 @@ export const config = [
     rules: {
       'no-unexpected-multiline': ERROR,
       'no-warning-comments': [ERROR, { terms: ['FIXME'], location: 'anywhere' }],
+      'no-console': [ERROR, { allow: ['warn', 'error'] }],
       'import/no-duplicates': [ERROR, { 'prefer-inline': true }],
       'import/no-self-import': ERROR,
       'import/no-relative-packages': ERROR,

--- a/src/typescript.json
+++ b/src/typescript.json
@@ -3,11 +3,13 @@
   "compilerOptions": {
     "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "lib": [
+      "ES2022",
+      "DOM",
+      "DOM.Iterable"
+    ],
     "module": "Preserve",
     "skipLibCheck": true,
-
-    /* Bundler mode */
     "moduleResolution": "Bundler",
     "allowImportingTsExtensions": true,
     "resolveJsonModule": true,
@@ -17,8 +19,6 @@
     "allowJs": false,
     "esModuleInterop": false,
     "jsx": "react-jsx",
-
-    /* Linting */
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -28,5 +28,7 @@
     "noUncheckedSideEffectImports": true,
     "noUncheckedIndexedAccess": true
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
-  "extends": "./src/tsconfig.json",
+  "extends": "./src/typescript.json",
   "include": ["**/*.ts", "**/*.tsx", "**/*.js", "**/*.jsx"],
   "exclude": ["node_modules"],
   "compilerOptions": {


### PR DESCRIPTION
- Renamed the TypeScript configuration file to avoid conflicts with the root `tsconfig.json` file;
- Add `no-console` rule.